### PR TITLE
Updates for change in external sharing

### DIFF
--- a/force-app/main/default/objects/Property_Favorite__c/Property_Favorite__c.object-meta.xml
+++ b/force-app/main/default/objects/Property_Favorite__c/Property_Favorite__c.object-meta.xml
@@ -52,7 +52,7 @@
     <enableSearch>true</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
-    <externalSharingModel>ReadWrite</externalSharingModel>
+    <!--externalSharingModel>ReadWrite</externalSharingModel-->
     <label>Property Favorite</label>
     <nameField>
         <displayFormat>F-{00000000}</displayFormat>

--- a/force-app/main/default/objects/Property__c/Property__c.object-meta.xml
+++ b/force-app/main/default/objects/Property__c/Property__c.object-meta.xml
@@ -55,7 +55,7 @@
     <enableSearch>true</enableSearch>
     <enableSharing>true</enableSharing>
     <enableStreamingApi>true</enableStreamingApi>
-    <externalSharingModel>ReadWrite</externalSharingModel>
+    <!--externalSharingModel>ReadWrite</externalSharingModel-->
     <label>Property</label>
     <nameField>
         <label>Property Name</label>


### PR DESCRIPTION
External sharing is no longer enabled by default in scratch orgs. Changes eliminate references in xml that interfere with ability to push source.