### PR TITLE
ran chmod 755 and fixed -d duration flag in orgInit.sh

### DIFF
--- a/scripts/orgInit.sh
+++ b/scripts/orgInit.sh
@@ -6,7 +6,7 @@ if [ "$#" -eq 1 ]; then
   DURATION=$1
 fi
 
-sfdx force:org:create -a dreamhouse -s -f config/project-scratch-def.json -f $DURATION
+sfdx force:org:create -a dreamhouse -s -f config/project-scratch-def.json -d $DURATION
 sfdx force:source:push
 sfdx force:user:permset:assign -n dreamhouse
 sfdx force:org:open -p /lightning/page/home


### PR DESCRIPTION
I was planning to show this in my talk and noticed the duration flag was wrong. 

Also orgInit.sh didn't have execute perms, so I ran chmod 755 before committing. 