### PR TITLE
Add missing files to resolve sequence of errors

### DIFF
--- a/.salesforcedx.yaml
+++ b/.salesforcedx.yaml
@@ -1,0 +1,5 @@
+scratch-org-def: config/project-scratch-def.json
+assign-permset: false
+run-apex-tests: true
+delete-scratch-org: false
+show-scratch-org-url: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DreamHouse Sample Application
 
+[![Deploy](https://deploy-to-sfdx.com/dist/assets/images/DeployToSFDX.svg)](https://deploy-to-sfdx.com)
+
 [![CircleCI](https://circleci.com/gh/dreamhouseapp/dreamhouse-sfdx.svg?style=svg)](https://circleci.com/gh/dreamhouseapp/dreamhouse-sfdx)
 
 Dreamhouse is a sample application for the real estate business built on the Salesforce platform. It allows brokers to manage their properties and customers to find their dream house.


### PR DESCRIPTION
This resolves the following sequence of errors from the **[Set Up Your Salesforce DX Environment](https://trailhead.salesforce.com/content/learn/projects/quick-start-salesforce-dx/set-up-your-salesforce-dx-environment)**  Trailhead module.

**Error 1:** ERROR: You do not have access to the [ScratchOrgInfo] object.
**Error 2:** ENOENT: no such file or directory, open 'config/project-scratch-def.json'.

Issue details are **[here](https://success.salesforce.com/answers?id=9063A0000019iEWQAY)**.