### PR TITLE
Removed reference to mobileReady on Property__c.tab-meta.xml 

### DIFF
--- a/force-app/main/default/tabs/Property__c.tab-meta.xml
+++ b/force-app/main/default/tabs/Property__c.tab-meta.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomTab xmlns="http://soap.sforce.com/2006/04/metadata">
     <customObject>true</customObject>
-    <mobileReady>false</mobileReady>
     <motif>Custom85: Real Estate Sign</motif>
 </CustomTab>


### PR DESCRIPTION
This field was removed in .46, see release notes: https://releasenotes.docs.salesforce.com/en-us/summer19/release-notes/rn_api_meta.htm

Custom Tabs
REMOVED: The deprecated field mobileReady has been removed from the CustomTab object
The mobileReady field is left over from the deprecated Salesforce Classic Mobile app. This field indicated whether a Visualforce page appeared in the Salesforce Classic Mobile app.