### PR TITLE
removed reference to mobileReady on property explorer 

### DIFF
--- a/force-app/main/default/tabs/Property_Explorer.tab-meta.xml
+++ b/force-app/main/default/tabs/Property_Explorer.tab-meta.xml
@@ -3,6 +3,5 @@
     <description>Created by Lightning App Builder</description>
     <flexiPage>Property_Explorer</flexiPage>
     <label>Property Explorer</label>
-    <mobileReady>false</mobileReady>
     <motif>Custom39: Telescope</motif>
 </CustomTab>


### PR DESCRIPTION
This field was removed in .46, see release notes: https://releasenotes.docs.salesforce.com/en-us/summer19/release-notes/rn_api_meta.htm

Custom Tabs
REMOVED: The deprecated field mobileReady has been removed from the CustomTab object
The mobileReady field is left over from the deprecated Salesforce Classic Mobile app. This field indicated whether a Visualforce page appeared in the Salesforce Classic Mobile app.