### PR TITLE
Removed reference to mobileReady in Sample_Data_Import.tab-meta.xml

### DIFF
--- a/force-app/main/default/tabs/Sample_Data_Import.tab-meta.xml
+++ b/force-app/main/default/tabs/Sample_Data_Import.tab-meta.xml
@@ -3,6 +3,5 @@
     <description>Created by Lightning App Builder</description>
     <flexiPage>Sample_Data_Import</flexiPage>
     <label>Sample Data Import</label>
-    <mobileReady>true</mobileReady>
     <motif>Custom67: Gears</motif>
 </CustomTab>


### PR DESCRIPTION
This field was removed in .46, see release notes: https://releasenotes.docs.salesforce.com/en-us/summer19/release-notes/rn_api_meta.htm

Custom Tabs
REMOVED: The deprecated field mobileReady has been removed from the CustomTab object
The mobileReady field is left over from the deprecated Salesforce Classic Mobile app. This field indicated whether a Visualforce page appeared in the Salesforce Classic Mobile app.