### PR TITLE
Salesforce is deprecating OrgPreferenceSettings

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -3,10 +3,16 @@
     "edition": "Developer",
     "hasSampleData": "false",
     "settings": {
-      "orgPreferenceSettings": {
-        "s1DesktopEnabled": true,
-        "selfSetPasswordInApi": true,
-        "s1EncryptedStoragePref2": false
-      }
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        },
+        "securitySettings": {
+            "passwordPolicies": {
+                "enableSetPasswordInApi": true
+            }
+        },
+        "mobileSettings": {
+            "enableS1EncryptedStoragePref2": false
+        }
     }
 }


### PR DESCRIPTION
WARNING: We're deprecating OrgPreferenceSettings. We've added the settings to other metadata types in Winter '20. You can continue to use OrgPreferenceSettings until they are replaced by their corresponding settings in Spring '20. But why wait? Here's exactly what you need to update in the scratch org definition file.

Replace the orgPreferenceSettings section:
{
    "settings": {
        "orgPreferenceSettings": {
            "s1DesktopEnabled": true,
            "selfSetPasswordInApi": true,
            "s1EncryptedStoragePref2": false
        }
    }
}
With their updated settings:
{
    "settings": {
        "lightningExperienceSettings": {
            "enableS1DesktopEnabled": true
        },
        "securitySettings": {
            "passwordPolicies": {
                "enableSetPasswordInApi": true
            }
        },
        "mobileSettings": {
            "enableS1EncryptedStoragePref2": false
        }
    }
}
For more info on configuring settings in a scratch org definition file see: 
https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs.htm